### PR TITLE
feat: add auth registration endpoint

### DIFF
--- a/src/main/java/fur/bunnyland/bunnylandapi/api/controller/AuthController.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/api/controller/AuthController.java
@@ -1,5 +1,11 @@
-package fur.bunnyland.bunnylandapi.controller;
+package fur.bunnyland.bunnylandapi.api.controller;
 
+import fur.bunnyland.bunnylandapi.api.dto.RegisterRequest;
+import fur.bunnyland.bunnylandapi.api.dto.RegisterResponse;
+import fur.bunnyland.bunnylandapi.api.dto.Role;
+import fur.bunnyland.bunnylandapi.domain.User;
+import fur.bunnyland.bunnylandapi.repository.UserRepository;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -8,11 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import fur.bunnyland.bunnylandapi.domain.User;
-import fur.bunnyland.bunnylandapi.repository.UserRepository;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -27,7 +30,7 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<UserResponse> register(@Valid @RequestBody RegisterRequest request) {
+    public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest request) {
         if (userRepository.existsByEmail(request.email())) {
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         }
@@ -35,15 +38,17 @@ public class AuthController {
         user.setEmail(request.email());
         user.setPasswordHash(passwordEncoder.encode(request.password()));
         user.setDisplayName(request.displayName());
+        user.setCity(request.city());
+        user.setCountry(request.country());
+        user.setRoles(Set.of("OWNER"));
         User saved = userRepository.save(user);
-        UserResponse response = new UserResponse(saved.getId(), saved.getEmail(), saved.getDisplayName());
+        RegisterResponse response = new RegisterResponse(saved.getId(),
+                saved.getEmail(),
+                saved.getDisplayName(),
+                saved.getCity(),
+                saved.getCountry(),
+                Set.of(Role.OWNER));
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
-    public record RegisterRequest(@Email @NotBlank String email,
-                                  @NotBlank String password,
-                                  String displayName) { }
-
-    public record UserResponse(Long id, String email, String displayName) { }
 }
 

--- a/src/main/java/fur/bunnyland/bunnylandapi/api/controller/HealthController.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/api/controller/HealthController.java
@@ -1,4 +1,4 @@
-package fur.bunnyland.bunnylandapi.controller;
+package fur.bunnyland.bunnylandapi.api.controller;
 
 import java.util.Map;
 

--- a/src/main/java/fur/bunnyland/bunnylandapi/api/dto/RegisterRequest.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/api/dto/RegisterRequest.java
@@ -1,0 +1,12 @@
+package fur.bunnyland.bunnylandapi.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterRequest(@Email @NotBlank String email,
+                              @NotBlank String password,
+                              String displayName,
+                              String city,
+                              String country) { }
+
+    

--- a/src/main/java/fur/bunnyland/bunnylandapi/api/dto/RegisterResponse.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/api/dto/RegisterResponse.java
@@ -1,0 +1,10 @@
+package fur.bunnyland.bunnylandapi.api.dto;
+
+import java.util.Set;
+
+public record RegisterResponse(Long id,
+                               String email,
+                               String displayName,
+                               String city,
+                               String country,
+                               Set<Role> roles) { }

--- a/src/main/java/fur/bunnyland/bunnylandapi/api/dto/Role.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/api/dto/Role.java
@@ -1,0 +1,6 @@
+package fur.bunnyland.bunnylandapi.api.dto;
+
+public enum Role {
+    ADMIN,
+    OWNER
+}

--- a/src/main/java/fur/bunnyland/bunnylandapi/config/SecurityConfig.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package fur.bunnyland.bunnylandapi.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -13,11 +15,16 @@ public class SecurityConfig {
                 http
                         .csrf(csrf -> csrf.disable())
                         .authorizeHttpRequests(authorize -> authorize
-                                .requestMatchers("/api/health", "/swagger-ui/**",
+                                .requestMatchers("/api/health", "/api/auth/**", "/swagger-ui/**",
                                         "/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated())
                         .httpBasic(h -> h.disable());
             //        http.httpBasic(Customizer.withDefaults()); // optional; JWT handles auth
             return http.build();
+        }
+
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+                return new BCryptPasswordEncoder();
         }
 }

--- a/src/main/java/fur/bunnyland/bunnylandapi/controller/AuthController.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/controller/AuthController.java
@@ -1,0 +1,49 @@
+package fur.bunnyland.bunnylandapi.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import fur.bunnyland.bunnylandapi.domain.User;
+import fur.bunnyland.bunnylandapi.repository.UserRepository;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthController(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<UserResponse> register(@Valid @RequestBody RegisterRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+        User user = new User();
+        user.setEmail(request.email());
+        user.setPasswordHash(passwordEncoder.encode(request.password()));
+        user.setDisplayName(request.displayName());
+        User saved = userRepository.save(user);
+        UserResponse response = new UserResponse(saved.getId(), saved.getEmail(), saved.getDisplayName());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    public record RegisterRequest(@Email @NotBlank String email,
+                                  @NotBlank String password,
+                                  String displayName) { }
+
+    public record UserResponse(Long id, String email, String displayName) { }
+}
+

--- a/src/main/java/fur/bunnyland/bunnylandapi/repository/UserRepository.java
+++ b/src/main/java/fur/bunnyland/bunnylandapi/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package fur.bunnyland.bunnylandapi.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import fur.bunnyland.bunnylandapi.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
+}
+

--- a/src/main/resources/db/migration/V2__insert_admin.sql
+++ b/src/main/resources/db/migration/V2__insert_admin.sql
@@ -1,0 +1,17 @@
+-- Create initial admin user
+INSERT INTO users (email, password_hash, display_name, city, country, created_at)
+VALUES (
+  'admin@bunnyland.com',
+  '$2a$10$h8cAKQF2XnTQpZihUhSivOqhz7zPh9tM3J9G2hGaaJDuslmip5qqq',
+  'Admin',
+  'Hamburg',
+  'Germany',
+  NOW()
+);
+
+-- Assign ADMIN role
+INSERT INTO user_roles (user_id, role)
+VALUES (
+  (SELECT id FROM users WHERE email = 'admin@bunnyland.com'),
+  'ADMIN'
+);

--- a/src/test/java/fur/bunnyland/bunnylandapi/AuthControllerIntegrationTest.java
+++ b/src/test/java/fur/bunnyland/bunnylandapi/AuthControllerIntegrationTest.java
@@ -1,0 +1,43 @@
+package fur.bunnyland.bunnylandapi;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import fur.bunnyland.bunnylandapi.domain.User;
+import fur.bunnyland.bunnylandapi.repository.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfiguration.class)
+class AuthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void registerPersistsUser() throws Exception {
+        userRepository.deleteAll();
+        mockMvc.perform(post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"test@example.com\",\"password\":\"secret\",\"displayName\":\"Test\"}"))
+                .andExpect(status().isCreated());
+
+        assertTrue(userRepository.existsByEmail("test@example.com"));
+        User user = userRepository.findByEmail("test@example.com").orElseThrow();
+        assertNotEquals("secret", user.getPasswordHash());
+    }
+}
+

--- a/src/test/java/fur/bunnyland/bunnylandapi/HealthControllerTest.java
+++ b/src/test/java/fur/bunnyland/bunnylandapi/HealthControllerTest.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import fur.bunnyland.bunnylandapi.config.SecurityConfig;
-import fur.bunnyland.bunnylandapi.controller.HealthController;
+import fur.bunnyland.bunnylandapi.api.controller.HealthController;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;


### PR DESCRIPTION
## Summary
- add `/api/auth/register` endpoint for user sign-up
- store new users with hashed passwords
- expose registration endpoint in security configuration
